### PR TITLE
Fix tests for new active/passive systems structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,17 +243,17 @@ mod macros
             $(#[$attr:meta])*
             struct $Name:ident<$components:ty, $services:ty> {
                 active: {
-                    $($field_name:ident : $field_ty:ty = $field_init:expr,)+
+                    $($field_name:ident : $field_ty:ty = $field_init:expr,)*
                 },
                 passive: {
-                    $($p_field_name:ident : $p_field_ty:ty = $p_field_init:expr,)+
+                    $($p_field_name:ident : $p_field_ty:ty = $p_field_init:expr,)*
                 }
             }
         } => {
             $(#[$attr])*
             pub struct $Name {
-                $(pub $field_name : $field_ty,)+
-                $(pub $p_field_name : $p_field_ty,)+
+                $(pub $field_name : $field_ty,)*
+                $(pub $p_field_name : $p_field_ty,)*
             }
 
             impl $crate::SystemManager for $Name
@@ -265,10 +265,10 @@ mod macros
                     $Name {
                         $(
                             $field_name : $field_init,
-                        )+
+                        )*
                         $(
                             $p_field_name : $p_field_init,
-                        )+
+                        )*
                     }
                 }
 
@@ -276,37 +276,37 @@ mod macros
                 {
                     $(
                         $crate::System::activated(&mut self.$field_name, &en, co, se);
-                    )+
+                    )*
                     $(
                         $crate::System::activated(&mut self.$p_field_name, &en, co, se);
-                    )+
+                    )*
                 }
 
                 fn __reactivated(&mut self, en: $crate::EntityData<$components>, co: &$components, se: &mut $services)
                 {
                     $(
                         $crate::System::reactivated(&mut self.$field_name, &en, co, se);
-                    )+
+                    )*
                     $(
                         $crate::System::reactivated(&mut self.$p_field_name, &en, co, se);
-                    )+
+                    )*
                 }
 
                 fn __deactivated(&mut self, en: $crate::EntityData<$components>, co: &$components, se: &mut $services)
                 {
                     $(
                         $crate::System::deactivated(&mut self.$field_name, &en, co, se);
-                    )+
+                    )*
                     $(
                         $crate::System::deactivated(&mut self.$p_field_name, &en, co, se);
-                    )+
+                    )*
                 }
 
-                fn __update(&mut self, co: &mut $crate::DataHelper<$components, $services>)
+                fn __update(&mut self, _co: &mut $crate::DataHelper<$components, $services>)
                 {
                     $(
-                        $crate::Process::process(&mut self.$field_name, co);
-                    )+
+                        $crate::Process::process(&mut self.$field_name, _co);
+                    )*
                 }
             }
         };

--- a/tests/general_tests.rs
+++ b/tests/general_tests.rs
@@ -33,12 +33,16 @@ components! {
 
 systems! {
     struct TestSystems<TestComponents, ()> {
-        hello_world: HelloWorld = HelloWorld("Hello, World!"),
-        print_position: EntitySystem<PrintPosition> = EntitySystem::new(PrintPosition,
-                aspect!(<TestComponents>
-                    all: [position, feature]
-                )
-            )
+        active: {
+            hello_world: HelloWorld = HelloWorld("Hello, World!"),
+        },
+        passive: {
+            print_position: EntitySystem<PrintPosition> = EntitySystem::new(PrintPosition,
+                                                                            aspect!(<TestComponents>
+                                                                                    all: [position, feature]
+                                                                            )
+            ),
+        }
     }
 }
 
@@ -68,7 +72,6 @@ impl EntityProcess for PrintPosition
 impl System for PrintPosition {
     type Components = TestComponents;
     type Services = ();
-    fn is_active(&self) -> bool { false }
 }
 
 #[test]

--- a/tests/tutorial_tests.rs
+++ b/tests/tutorial_tests.rs
@@ -99,7 +99,6 @@ pub mod chapter5 {
     impl System for PrintMessage {
         type Components = MyComponents;
         type Services = ();
-        fn is_active(&self) -> bool { false }
     }
     impl Process for PrintMessage {
         fn process(&mut self, _: &mut DataHelper<MyComponents, ()>) {
@@ -109,7 +108,11 @@ pub mod chapter5 {
 
     systems! {
         struct MySystems<MyComponents, ()> {
-            print_msg: PrintMessage = PrintMessage("Hello World".to_string())
+            active: {
+            },
+            passive: {
+                print_msg: PrintMessage = PrintMessage("Hello World".to_string()),
+            }
         }
     }
 
@@ -160,7 +163,11 @@ pub mod chapter6 {
 
     systems! {
         struct MySystems<MyComponents, ()> {
-            motion: EntitySystem<MotionProcess> = EntitySystem::new(MotionProcess, aspect!(<MyComponents> all: [position, velocity]))
+            active: {
+                motion: EntitySystem<MotionProcess> = EntitySystem::new(MotionProcess, aspect!(<MyComponents> all: [position, velocity])),
+            },
+            passive: {
+            }
         }
     }
 


### PR DESCRIPTION
The tests were broken because they were not yet using the new active/passive structure for systems. Also, this pull request makes it possible to call systems! with an empty list of active or passive systems (there isn't really a reason not to allow this).