### PR TITLE
Add missing commas in tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -202,8 +202,8 @@ To add the system, we modify our call to the `systems!` macro to look like this:
 systems! {
     struct MySystems<MyComponents, ()> {
         active: {
-            print_msg: PrintMessage = PrintMessage("Hello World".to_string())
-        }
+            print_msg: PrintMessage = PrintMessage("Hello World".to_string()),
+        },
         passive: {}
     }
 }


### PR DESCRIPTION
Some lines in tutorial.md are missing commas which prevents the code from compiling.