### PR TITLE
Allow with_entity_data to take moving closures

### DIFF
--- a/src/world.rs
+++ b/src/world.rs
@@ -86,8 +86,8 @@ impl<C: ComponentManager, M: ServiceManager> DerefMut for DataHelper<C, M>
 
 impl<C: ComponentManager, M: ServiceManager> DataHelper<C, M>
 {
-    pub fn with_entity_data<F, R>(&mut self, entity: &Entity, mut call: F) -> Option<R>
-        where F: FnMut(EntityData<C>, &mut C) -> R
+    pub fn with_entity_data<F, R>(&mut self, entity: &Entity, call: F) -> Option<R>
+        where F: FnOnce(EntityData<C>, &mut C) -> R
     {
         if self.entities.is_valid(entity) {
             Some(call(EntityData(&self.entities.indexed(&entity).__clone()), self))


### PR DESCRIPTION
So far, `DataHelper::with_entity_data` takes a `FnMut` but only ever calls it once at most.

By changing this to `FnOnce` closures that move their environment can also be used.

This should not be a breaking change since any place that uses a `Fn` or `FnMut` as argument will still work, so it should allow strictly more uses of the method.

A drawback would be if the requirement on `FnMut` became necessary in the future, in which case switching back would be a breaking change.